### PR TITLE
Return transformed coordinates when dragging in progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ node_modules
 
 # Users Environment Variables
 .lock-wscript
+
+# IDE
+*.iml

--- a/src/Edit.Circle.Drag.js
+++ b/src/Edit.Circle.Drag.js
@@ -103,8 +103,13 @@ L.Edit.Circle.include( /** @lends L.Edit.Circle.prototype */ {
   }
 });
 
+// store original letLatLng to call in override
 L.Circle.prototype.__getLatLng = L.Circle.prototype.getLatLng;
 
+/**
+ * Return transformed point in case if dragging is enabled and in progress,
+ * otherwise - call original method.
+ */
 L.Circle.prototype.getLatLng = function() {
   if (this.dragging && this.dragging._matrix) {
     return this.dragging._transformPoint(this.dragging._matrix, this._latlng);

--- a/src/Edit.Circle.Drag.js
+++ b/src/Edit.Circle.Drag.js
@@ -46,7 +46,7 @@ L.Edit.Circle.include( /** @lends L.Edit.Circle.prototype */ {
    * @param  {L.LatLng} latlng
    */
   _resize: function(latlng) {
-    var center = this._shape.getLatLng();
+    var center = this._shape._latlng;
     var radius = center.distanceTo(latlng);
 
     this._shape.setRadius(radius);
@@ -91,7 +91,7 @@ L.Edit.Circle.include( /** @lends L.Edit.Circle.prototype */ {
    * @param  {L.MouseEvent} evt
    */
   _onStopDragFeature: function() {
-    var center = this._shape.getLatLng();
+    var center = this._shape._latlng;
 
     //this._moveMarker.setLatLng(center);
     this._resizeMarkers[0].setLatLng(this._getResizeMarkerPoint(center));
@@ -102,3 +102,13 @@ L.Edit.Circle.include( /** @lends L.Edit.Circle.prototype */ {
     this._fireEdit();
   }
 });
+
+L.Circle.prototype.__getLatLng = L.Circle.prototype.getLatLng;
+
+L.Circle.prototype.getLatLng = function() {
+  if (this.dragging && this.dragging._matrix) {
+    return this.dragging._transformPoint(this.dragging._matrix, this._latlng);
+  } else {
+    return this.__getLatLng();
+  }
+};


### PR DESCRIPTION
Hi @w8r,

Thank you for your work and plugin!

I've already opened PR in your another plugin: https://github.com/w8r/Leaflet.Path.Drag/pull/13. It should be merged before this one.

Let me describe the goal of this PR. 

When dragging is enabled and and is in progress, if I call `getLatLng` method, for example in L.Circle - I will get old, outdated coordinates, because actual transformation is applied only when dragging is finished. I understand, that it was made intentionally, for performance reason. That's why I tried to follow the idea and have overridden the method `getLatLng`. Now, if we call getLatLng in process of dragging - it will return tranformed coordinates. But actual transformation wasn't changed and will be done at the end of dragging, as it was before.

Use case scenario: we want to bind a label to the center of a shape. When we drag the shape - the label should also be moved. So we should bind to the shapes' `drag` event and change the coordinates of label according to new shape position.