### PR TITLE
Use `global` library instead of directly use `global` variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-var L = global.L || require('leaflet');
+var g = require('global');
+var L = g.L || require('leaflet');
 require('leaflet-draw');
 require('leaflet-path-drag');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -244,7 +244,7 @@
     },
     "async-cache": {
       "version": "1.1.0",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/async-cache/-/async-cache-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/async-cache/-/async-cache-1.1.0.tgz",
       "integrity": "sha1-SppaidBl7F2OUlS9nulrp2xTK1o=",
       "dev": true,
       "requires": {
@@ -861,7 +861,7 @@
     },
     "deep-is": {
       "version": "0.1.3",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/deep-is/-/deep-is-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
@@ -1233,7 +1233,7 @@
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
@@ -1475,7 +1475,7 @@
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
@@ -1885,7 +1885,7 @@
     },
     "natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/natural-compare/-/natural-compare-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
@@ -2076,7 +2076,7 @@
     },
     "pseudomap": {
       "version": "1.0.2",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/pseudomap/-/pseudomap-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
@@ -2436,7 +2436,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
@@ -2601,7 +2601,7 @@
     },
     "text-table": {
       "version": "0.2.0",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/text-table/-/text-table-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
@@ -2892,7 +2892,7 @@
     },
     "yallist": {
       "version": "2.1.2",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/yallist/-/yallist-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -923,6 +923,11 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
+    },
     "domain-browser": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
@@ -1369,6 +1374,15 @@
       "dev": true,
       "requires": {
         "is-glob": "^2.0.0"
+      }
+    },
+    "global": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "requires": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
       }
     },
     "globals": {
@@ -1820,6 +1834,14 @@
       "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
       "dev": true
     },
+    "min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==",
+      "requires": {
+        "dom-walk": "^0.1.0"
+      }
+    },
     "minimalistic-assert": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
@@ -2059,8 +2081,7 @@
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-      "dev": true
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "process-nextick-args": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "global": "^4.4.0",
     "leaflet-draw": "^0.4.12",
     "leaflet-path-drag": "^1.1.0"
   },


### PR DESCRIPTION
This library [tests](https://github.com/Raynos/global/blob/master/window.js) whether to use `global` (nodejs) or `window` (browsers) in a opaque way so that library users do not need to care about implementation details.

This should fix #39.

[Using `globalThis` would be preferable](https://github.com/w8r/Leaflet.draw.drag/pull/47), but this pull request is an alternative to that.