### PR TITLE
Use `globalThis` instead of `global`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var L = global.L || require('leaflet');
+var L = globalThis.L || require('leaflet');
 require('leaflet-draw');
 require('leaflet-path-drag');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -244,7 +244,7 @@
     },
     "async-cache": {
       "version": "1.1.0",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/async-cache/-/async-cache-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/async-cache/-/async-cache-1.1.0.tgz",
       "integrity": "sha1-SppaidBl7F2OUlS9nulrp2xTK1o=",
       "dev": true,
       "requires": {
@@ -861,7 +861,7 @@
     },
     "deep-is": {
       "version": "0.1.3",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/deep-is/-/deep-is-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
@@ -1233,7 +1233,7 @@
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
@@ -1475,7 +1475,7 @@
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
@@ -1885,7 +1885,7 @@
     },
     "natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/natural-compare/-/natural-compare-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
@@ -2076,7 +2076,7 @@
     },
     "pseudomap": {
       "version": "1.0.2",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/pseudomap/-/pseudomap-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
@@ -2436,7 +2436,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
@@ -2601,7 +2601,7 @@
     },
     "text-table": {
       "version": "0.2.0",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/text-table/-/text-table-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
@@ -2892,7 +2892,7 @@
     },
     "yallist": {
       "version": "2.1.2",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/yallist/-/yallist-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },


### PR DESCRIPTION
Sort of fulfils the same purpose as the [`global` library](https://github.com/Raynos/global), but [`globalThis`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis) is a more modern and newer [official ECMAScript language feature](https://tc39.es/ecma262/multipage/global-object.html#sec-globalthis) ([full support](https://caniuse.com/?search=globalThis)).

This should fix #39.

This is the preferred way to resolve this, but there is an [alternative pull request](https://github.com/w8r/Leaflet.draw.drag/pull/46).